### PR TITLE
Feature photo url util

### DIFF
--- a/config.js
+++ b/config.js
@@ -2,4 +2,5 @@ module.exports = {
   host: '0.0.0.0',
   port: 8000,
   urlRoot: 'http://127.0.0.1:8000',
+  appRoot: require('app-root-path').toString(), // robust util for getting app root.
 };

--- a/package.json
+++ b/package.json
@@ -1,5 +1,9 @@
 {
+  "scripts": {
+    "start": "npm install && node ."
+  },
   "dependencies": {
+    "app-root-path": "^1.0.0",
     "bcrypt": "^0.8.4",
     "good": "^6.3.0",
     "good-console": "^5.0.2",

--- a/utils.js
+++ b/utils.js
@@ -1,0 +1,29 @@
+var config = require('./config.js');
+var fs = require('fs');
+var path = require('path');
+
+/**
+ * Given a path to a photo, produces a URL for accessing the photo
+ * over the network.
+ * @param  {String} photoPath The path to the photo on the server. This should
+ *                            be relative to the root directory of the server.
+ * @return {String}           The URL for accessing the photo. If no photoPath
+ *                            provided or no available resource is accessible
+ *                            at that filesystem path, returns the empty string.
+ */
+function getPhotoUrl(photoPath) {
+  try { // Test that path exists and the server has read access.
+    var absolutePath = path.join(config.appRoot, photoPath);
+    fs.statSync(absolutePath);
+  } catch (exception) {
+    console.log('Warn: getPhotoUrl() failed as the path "'+ absolutePath +'"' +
+                ' does not exist or permissions are incorrectly set.');
+    return '';
+  }
+
+  return config.urlRoot + photoPath;
+}
+
+module.exports = {
+  getPhotoUrl: getPhotoUrl,
+};


### PR DESCRIPTION
Adds a `getPhotoUrl()` utility that allows for constructing URLs for accessing the photo over the network, give a server path. Also adds a new dependency to the project for reliably getting the server root in various different environments.

Lastly adds a `npm run start` script so that client and server are started in the same way (also allows to force an npm install to run prior to starting up so people don't forget to update dependencies when they have changed).
