### PR TITLE
(RRequest) Payload names changed with frontend

### DIFF
--- a/handlers/userRepairs.js
+++ b/handlers/userRepairs.js
@@ -46,7 +46,7 @@ function postHandler(request, reply, userId) {
              'VALUES (?, ?, ?, ?)',
         values:[
           payload.description,
-          payload.dataUri,
+          payload.image,
           userId,
           propertyId
         ],


### PR DESCRIPTION
Frontend now uses ‘image’ as the attribute.
Reflecting changes in server API
